### PR TITLE
Issue #8 Refactor to handle multiple mentions of Git repo

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -13,7 +13,6 @@ var hn_api_host = 'hacker-news.firebaseio.com';
 var post_details_url_suffix = '.json';
 var gh_responses = [];
 
-
 var httpGet = function(host, path, cb) {
     var options = {
         host: host,
@@ -35,68 +34,86 @@ var httpGet = function(host, path, cb) {
     });
 };
 
-function saveGithubPost(data, hn_data) {
-    var post = JSON.parse(data);
-    if (!post.name) { // probably an API ratelimiting issue
-      console.error("Could not get Github post! Received data: ");
-      console.error(post);
+function saveGithubPost(data) {
+    var project = JSON.parse(data);
+    if (!project.name) { // probably an API ratelimiting issue
+      console.error("Could not get Github project! Received data: ");
+      console.error(project);
       return;
     }
     knex('ghprojects').insert({
-      hn_id: hn_data.id,
-      hn_url: "https://news.ycombinator.com/item?id=" + hn_data.id,
-      gh_url: post.html_url,
-      gh_name: post.name,
-      gh_description: post.description,
-      gh_stars: post.stargazers_count,
-      gh_language: post.language
+      gh_url: project.html_url,
+      gh_name: project.name,
+      gh_description: project.description,
+      gh_stars: project.stargazers_count,
+      gh_language: project.language
     }).then(function() {
-      console.log("New project: " + post.name + " | hn id: " + hn_data.id);
-    })
-    .catch(function(error) {
+      console.log("New project: " + project.name)
+    }).catch(function(error) {
       console.log(error);
     });
+}
+
+function hnItemUrl(itemId) {
+  return 'https://news.ycombinator.com/item?id=' + itemId;
 }
 
 function checkPost(data) {
     var post_details = JSON.parse(data);
     var repository_url = /https?:\/\/github.com(\/.*?\/[^\/]*).*?/.exec(
         post_details.url);
-    if (repository_url) {
-        httpGet('api.github.com', '/repos' + repository_url[1],
-          function(gh_api_data) {
-            saveGithubPost(gh_api_data, post_details);
-          }
-        );
+    if (!repository_url) {
+      return;
     }
+    knex('hnposts').insert({
+      id: post_details.id,
+      gh_url: repository_url[0],
+      retrievedAt: Date.now(),
+      hn_url: hnItemUrl(post_details.id),
+      hn_time: post_details.time
+    }).then(function () {
+      httpGet('api.github.com', '/repos' + repository_url[1], saveGithubPost);
+    }).catch(function(error) {
+      console.error(error);
+    });
 }
 
 function processHNPosts(data) {
     var current_time = new Date();
     var top_list = JSON.parse(data);
     top_list.forEach(function(entry) {
-      knex('hnposts').insert({id: entry, retrievedAt: current_time})
-        .then(function () {
-          httpGet(hn_api_host,
-                '/v0/item/' + entry + post_details_url_suffix, checkPost);
-        })
-        .catch(function(error) {
-          console.log(error);
-        });
+      httpGet(hn_api_host,
+        '/v0/item/' + entry + post_details_url_suffix, checkPost);
     });
 }
 
 function clearOldPosts() {
     var date = new Date();
     date.setHours(date.getHours() - 2);
-    knex.select('*').from('hnposts')
-        .leftOuterJoin('ghprojects', 'hnposts.id', 'ghprojects.hn_id')
-        .whereNull('gh_url')
-        .where('retrievedAt', '<', date)
-        .del();
+
+    // Split into two queries - join deletes aren't supported
+    // https://github.com/tgriesser/knex/issues/873
+    knex('hnposts')
+      .distinct('gh_url')
+      .select()
+      .where('retrievedAt', '<', date)
+      .then(function(posts) {
+        var ghUrls = posts.map(function(post) { return post.gh_url });
+
+        knex('hnposts')
+          .whereIn('gh_url', ghUrls)
+          .del();
+
+        knex('ghprojects')
+          .whereIn('gh_url', ghUrls)
+          .del();
+      }).catch(function(error) {
+        console.error(error);
+      });
 }
 
 module.exports.httpGet = httpGet;
 module.exports.hn_api_host = hn_api_host;
 module.exports.processHNPosts = processHNPosts;
 module.exports.clearOldPosts = clearOldPosts;
+module.exports.hnItemUrl = hnItemUrl;

--- a/clock.js
+++ b/clock.js
@@ -12,7 +12,7 @@ function runJob() {
         backend.hn_api_host,
         '/v0/topstories.json',
         backend.processHNPosts);
-        backend.clearOldPosts();
+    backend.clearOldPosts();
 }
 
 module.exports.forceUpdate = runJob;

--- a/migrations/20141229012503_00.js
+++ b/migrations/20141229012503_00.js
@@ -1,16 +1,17 @@
 'use strict';
 
 exports.up = function(knex, Promise) {
-   return knex.schema.createTable('hnposts', function (table) {
-    table.integer('id').primary();
-    table.timestamp('retrievedAt');
-  }).createTable('ghprojects', function (table) {
-    table.integer('hn_id').references('id').inTable('hnposts');
-    table.string('hn_url');
+   return knex.schema.createTable('ghprojects', function (table) {
     table.string('gh_url').primary();
     table.string('gh_name');
     table.string('gh_description');
     table.string('gh_language');
+  }).createTable('hnposts', function (table) {
+   table.integer('id').primary();
+   table.string('gh_url').references('gh_url').inTable('ghprojects');
+   table.timestamp('retrievedAt');
+   table.string('hn_url');
+   table.string('hn_time');
   });
 };
 

--- a/routes.js
+++ b/routes.js
@@ -3,24 +3,56 @@ var backend = require('./backend');
 module.exports = function(app) {
   var knex = app.get('knex');
 
-  var searchLanguage = function(res, language) {
-    knex.select('*')
+  function displayUTCDate(timestamp) {
+    var date = new Date(Number(timestamp) * 1000);
+    return date.toLocaleDateString();
+  }
+
+  function makeBaseQuery() {
+    return knex.select(
+      'ghprojects.gh_url',
+      'ghprojects.gh_name',
+      'ghprojects.gh_description',
+      'ghprojects.gh_stars',
+      'ghprojects.gh_language',
+      knex.raw('count(*) as hn_mentions'),
+      knex.raw('min(hnposts.hn_time) as hn_first_mention_timestamp'),
+      knex.raw('max(hnposts.hn_time) as hn_last_mention_timestamp'),
+      knex.raw('min(hnposts.id) as hn_first_mention_id'),
+      knex.raw('max(hnposts.id) as hn_last_mention_id')
+    )
       .from('ghprojects')
-      .whereRaw('LOWER(gh_language) = LOWER(?)', [language])
-      .orderBy('hn_id', 'desc')
+      .join('hnposts', 'ghprojects.gh_url', 'hnposts.gh_url')
+      .groupBy('ghprojects.gh_url')
+      .orderBy('hn_last_mention_id', 'desc');
+  }
+
+  var searchLanguage = function(res, language) {
+      makeBaseQuery()
+      .whereRaw('LOWER(ghprojects.gh_language) = LOWER(?)', [language])
       .then(function (projects) {
         return res.render('index.hjs', {
           filter_lang: language,
-          projects: projects
+          projects: projects,
+          hnItemUrl: backend.hnItemUrl,
+          displayUTCDate: displayUTCDate
         });
+      }).catch(function (error) {
+        console.error(error);
       });
   };
 
   app.get('/', function (req, res) {
-    knex.select('*').from('ghprojects')
-    .orderBy('hn_id', 'desc').then(function(projects) {
-      return res.render('index.hjs', { projects: projects });
-    });
+      makeBaseQuery()
+      .then(function(projects) {
+        return res.render('index.hjs', {
+          projects: projects,
+          hnItemUrl: backend.hnItemUrl,
+          displayUTCDate: displayUTCDate
+        });
+      }).catch(function (error) {
+        console.error(error);
+      });
   });
 
   app.get('/refresh-content', function (req, res) {
@@ -29,7 +61,7 @@ module.exports = function(app) {
         backend.hn_api_host,
         '/v0/topstories.json',
         backend.processHNPosts);
-        backend.clearOldPosts();
+    backend.clearOldPosts();
     res.redirect('/');
   });
 

--- a/views/index.hjs
+++ b/views/index.hjs
@@ -34,12 +34,15 @@
 			<td class='proj-language nowrap'>
 				Language
 			</td>
-			<td class='hn-post nowrap'>
-				Hacker News
-			</td>
 			<td class='gh-stars nowrap'>
 				Stars
 			</td>
+			<td class='hn-post nowrap'>
+				Hacker News
+			</td>
+			<td class='hn-post nowrap'>
+			</td>
+		</tr>
 		{% for project in projects %}
 		<tr class='project'>
 			<td class='proj-title'>
@@ -52,12 +55,29 @@
 			<td class='proj-language'>
 				<a href="/{{ project.gh_language | urlencode }}">{{ project.gh_language }}</a>
 			</td>
-			<td class='hn-post'>
-				<a href='{{ project.hn_url }}'> Read on HN </a>
-			</td>
 			<td class='gh-stars nowrap'>
 				🌟  {{project.gh_stars}}
 			</td>
+			{% if project.hn_first_mention_timestamp == project.hn_last_mention_timestamp %}
+			<td class='hn-post'>
+				<a href='{{ hnItemUrl(project.hn_first_mention_id) }}' title='{{ displayUTCDate(project.hn_first_mention_timestamp) }} '>
+					Read on HN
+				</a>
+			</td>
+			<td class='hn-post'>
+			</td>
+			{% else %}
+			<td class='hn-post'>
+				<a href='{{ hnItemUrl(project.hn_first_mention_id) }}' title='{{ displayUTCDate(project.hn_first_mention_timestamp) }} '>
+					Oldest
+				</a>
+			</td>
+			<td class='hn-post'>
+				<a href='{{ hnItemUrl(project.hn_last_mention_id) }}' title='{{ displayUTCDate(project.hn_last_mention_timestamp) }} '>
+					Newest
+				</a>
+			</td>
+			{% endif %}
 		</tr>
 		{% endfor %}
 	</table>


### PR DESCRIPTION
The core of this change rewires the database so that hnposts are children of git repositories.  In the context of this project, this makes sense: we care about the repos, and 1 or more hnposts has mentioned them.

This allows us to do some interesting things, including displaying and linking to the first and last mentions of a project, and the total mentions.

I couldn't find a `knex` syntax for selecting \* from just one table, e.g. `select * from a.*`. So listed out all the columns needed. Refactored shared parts of the query into a base query that could be shared, minimizing duplicated code.

This requires a complete drop, re-add, and then re-population of the database.
