### PR TITLE
Fix styling and add a little logging

### DIFF
--- a/backend.js
+++ b/backend.js
@@ -37,6 +37,11 @@ var httpGet = function(host, path, cb) {
 
 function saveGithubPost(data, hn_data) {
     var post = JSON.parse(data);
+    if (!post.name) { // probably an API ratelimiting issue
+      console.error("Could not get Github post! Received data: ");
+      console.error(post);
+      return;
+    }
     knex('ghprojects').insert({
       hn_id: hn_data.id,
       hn_url: "https://news.ycombinator.com/item?id=" + hn_data.id,
@@ -44,6 +49,8 @@ function saveGithubPost(data, hn_data) {
       gh_name: post.name,
       gh_description: post.description,
       gh_language: post.language
+    }).then(function() {
+      console.log("New project: " + post.name + " | hn id: " + hn_data.id);
     })
     .catch(function(error) {
       console.log(error);

--- a/static/style.css
+++ b/static/style.css
@@ -10,6 +10,26 @@
     padding-right: 10px;
 }
 
+tr.project > td
+{
+  padding-bottom: 0.5em;
+}
+
+.proj-description-content {
+  position: relative;
+  overflow: hidden;
+  max-height: 4.0em;
+}
+
+.proj-description-shadow {
+    position:absolute;
+    top: 3.0em;
+    width:100%;
+    height:1.0em;
+    background: linear-gradient(transparent, white);
+}
+
+
 .proj-language {
     padding-right: 10px;
     padding-left: 10px;

--- a/views/index.hjs
+++ b/views/index.hjs
@@ -43,7 +43,8 @@
 				<a href='{{ project.gh_url }}'> {{ project.gh_name }} </a>
 			</td>
 			<td class='proj-description'>
-				{{ project.gh_description }}
+				<div class='proj-description-content'>
+					<div class='proj-description-shadow'></div>{{ project.gh_description }}</div>
 			</td>
 			<td class='proj-language'>
 				<a href="/{{ project.gh_language | urlencode }}">{{ project.gh_language }}</a>


### PR DESCRIPTION
This adds some padding, makes long (~3 lines or longer) descriptions fade out, and adds some logging. Turns out that recreating the database a million times makes github mad, who would've guessed :)

@iankronquist 
